### PR TITLE
feat(link): 更新 EasyTier 到 2.4.5

### DIFF
--- a/Link/EasyTier/ETInfoProvider.cs
+++ b/Link/EasyTier/ETInfoProvider.cs
@@ -57,7 +57,7 @@ public static class ETInfoProvider
 {
     public const string ETNetworkNamePrefix = "PCLCELobby";
     public const string ETNetworkSecretPrefix = "PCLCEETLOBBY2025";
-    public const string ETVersion = "2.4.3";
+    public const string ETVersion = "2.4.5";
     public static readonly string ETPath = Path.Combine(FileService.LocalDataPath, "EasyTier", ETVersion,
         "easytier-windows-" + (RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64" : "x86_64"));
 

--- a/Link/Lobby/LobbyInfoProvider.cs
+++ b/Link/Lobby/LobbyInfoProvider.cs
@@ -15,7 +15,7 @@ public static class LobbyInfoProvider
     public static bool AllowCustomName { get; set; } = false;
     public static bool RequiresLogin { get; set; } = true;
     public static bool RequiresRealName { get; set; } = true;
-    public static int ProtocolVersion { get; set; } = 4;
+    public static int ProtocolVersion { get; set; } = 5;
 
     public static Broadcast? McBroadcast { get; internal set; }
     public static TcpForward? McForward { get; internal set; }


### PR DESCRIPTION
合并此 PR 即开始 2.13.0 Slow Ring 发版流程，因为提升了联机协议版本。

还需要同步修改远程 API 的协议版本要求。