### PR TITLE
imp(launch): 添加 preferIPvXAddresses 参数

### DIFF
--- a/Minecraft/Launch/Services/Argument/JvmArgBuilder.cs
+++ b/Minecraft/Launch/Services/Argument/JvmArgBuilder.cs
@@ -369,9 +369,11 @@ public class JvmArgBuilder(IMcInstance instance) {
         switch (Config.Launch.PreferredIpStack) {
             case 0:
                 arguments.Add("-Djava.net.preferIPv4Stack=true");
+                arguments.Add("-Djava.net.preferIPv4Addresses=true");
                 break;
             case 2:
                 arguments.Add("-Djava.net.preferIPv6Stack=true");
+                arguments.Add("-Djava.net.preferIPv6Addresses=true");
                 break;
         }
     }


### PR DESCRIPTION
在启动设置中选择了 IP 偏好后，将会同时添加 `-Djava.net.preferIPvXAddresses=true`